### PR TITLE
Idea for a general lstart.sh 

### DIFF
--- a/lstart2.sh
+++ b/lstart2.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+  
+# make the assumption of a lab.conf file in which all the routers
+# are named just rx where x is a number.
+
+devices=$(grep -oP '[a-z]{1,2}[0-9]{1}\[' lab.conf | sort --unique)
+sudo kathara lstart --privileged
+for device in $devices; do
+        device=${device%?}
+        if [ ${device%?} = "r"  ]; then
+                xrdb ../.XDefaults.alt
+                xterm -e bash -c "kathara connect $device" &
+        else
+                xrdb ../.XDefaults
+                xterm -e bash -c "kathara connect $device" &
+        fi
+done
+


### PR DESCRIPTION
hi, I come up with a really simple version of the lstart.sh script used today in class which can be used for all the exercises without the need to modify it according to the specific lab.conf file. It works assuming the routers are named `rx` where `x` is a single digit number. 